### PR TITLE
Add shareableObject as a settings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ Features
     - Attractive buttons and multiple themes
     - Easy to implement with just a few lines of code
     
+Options
+================
+```jquery
+$('#shareable').share({
+  networks: ['facebook', 'twitter', 'linkedin', 'in1', 'tumblr', 'digg', 'googleplus', 'reddit', 'pinterest', 'posterous', 'stumbleupon', 'email']
+  theme: 'square' or 'icon',
+  orientation: 'vertical' or 'horizontal',
+  affix: 'top', or 'top left', or 'top center', or 'top right', or 'left center', or 'left bottom', or 'right center', or 'right bottom', or 'bottom left', or 'bottom center', or 'bottom right',
+  margin: 'margin between icons [default is 3px]',
+  title: 'text that is shared [default is page title]',
+  urlToShare: 'url that is shared [default is current page url]',
+  shareableObject: 'customize the title tag on the link [default is page]',
+  pageDesc:
+});
+```
+
 Examples
 ================
 

--- a/jquery.share.js
+++ b/jquery.share.js
@@ -25,6 +25,7 @@
                     margin = this.share.settings.margin,
                     pageTitle = this.share.settings.title||$(document).attr('title'),
                     pageUrl = this.share.settings.urlToShare||$(location).attr('href'),
+                    shareableObject = this.share.settings.shareableObject||'page',
                     pageDesc = "";
                 
                 $.each($(document).find('meta[name="description"]'),function(idx,item){
@@ -46,7 +47,7 @@
                         href = helpers.networkDefs[item].url;
                         href = href.replace('|u|',u).replace('|t|',t).replace('|d|',d)
                                    .replace('|140|',t.substring(0,130));
-                        $("<a href='"+href+"' title='Share this page on "+item+
+                        $("<a href='"+href+"' title='Share this " + shareableObject + " on "+item+
                             "' class='pop share-"+theme+" share-"+theme+"-"+item+"'></a>")
                             .appendTo($element);
                     }


### PR DESCRIPTION
Allow the title tag to contain more accurate information about the thing being shared.
