### PR TITLE
Modify .pop click binding

### DIFF
--- a/jquery.share.js
+++ b/jquery.share.js
@@ -84,9 +84,9 @@
                     }
                     
                     // bind click
-                    $('.pop').click(function(){
+                    $(document).on('click', '.pop', function(evt){
                         window.open($(this).attr('href'),'t','toolbar=0,resizable=1,status=0,width=640,height=528');
-                        return false;
+                        evt.preventDefault();
                     });
                     
                     


### PR DESCRIPTION
Use a delegate instead of an eventhandler, so creation/deletion of shares won't affect it.  Also use evt.preventDefault instead of return false so other delegates can have access to the event.
